### PR TITLE
Fixed issue in check_data function when CloudStack returns 0 for usag…

### DIFF
--- a/lib/cloudstack-nagios/helper.rb
+++ b/lib/cloudstack-nagios/helper.rb
@@ -39,6 +39,9 @@ module CloudstackNagios
 
     def check_data(total, usage, warning, critical)
       usage_percent = (100.0 / total.to_f * usage.to_f) || 0.0
+      if usage_percent.nan?
+        usage_percent = 0.0
+      end
       code = 3
       if usage_percent < warning
         code = 0


### PR DESCRIPTION
…e and total. It's some CloudStack bug we experienced.
Without this fix, if CloudStack returns 0 for usage, usage_percent will be NaN and check_data function will fail at "[code, usage_percent.round(0)]".